### PR TITLE
Default to global linkscope when @linkscope is not set

### DIFF
--- a/transclusion-fixup.xsl
+++ b/transclusion-fixup.xsl
@@ -35,7 +35,7 @@
     </xsl:when>
 
     <xsl:when test="($fixup='prefix' or $fixup='auto')
-                    and ($linkscope='local' or empty($linkscope))">
+                    and $linkscope='local'">
       <xsl:choose>
         <xsl:when test="$fixup='auto'">
           <xsl:variable name="id" select="concat('idf-', generate-id($xiroot), '-', .)"/>


### PR DESCRIPTION
Elsewhere in the xslt, it defaults to global linkscope when @linkscope has not been set. This makes more sense to me since linkescope="local" is potentially brittle if the xincluded content contains xrefs outside the content. 
